### PR TITLE
feat(*): preserve key order when using Find task

### DIFF
--- a/src/main/java/io/kestra/plugin/mongodb/AbstractLoad.java
+++ b/src/main/java/io/kestra/plugin/mongodb/AbstractLoad.java
@@ -43,7 +43,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
         title = "Chunk size for every bulk request."
     )
     @Builder.Default
-    private Property<Integer> chunk = Property.of(1000);
+    private Property<Integer> chunk = Property.ofValue(1000);
 
     abstract protected Flux<WriteModel<Bson>> source(RunContext runContext, BufferedReader inputStream) throws Exception;
 

--- a/src/main/java/io/kestra/plugin/mongodb/Delete.java
+++ b/src/main/java/io/kestra/plugin/mongodb/Delete.java
@@ -63,7 +63,7 @@ public class Delete extends AbstractTask implements RunnableTask<Delete.Output> 
     )
     @Builder.Default
     @NotNull
-    private Property<Operation> operation = Property.of(Operation.DELETE_ONE);
+    private Property<Operation> operation = Property.ofValue(Operation.DELETE_ONE);
 
     @Override
     public Delete.Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/mongodb/Find.java
+++ b/src/main/java/io/kestra/plugin/mongodb/Find.java
@@ -63,7 +63,7 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
             code = """
                 id: filter_mongodb
                 namespace: company.team
-                
+
                 tasks:
                   - id: filter
                     type: io.kestra.plugin.mongodb.Find
@@ -116,7 +116,7 @@ public class Find extends AbstractTask implements RunnableTask<Find.Output> {
         title = "Whether to store the data from the query result into an ion serialized data file."
     )
     @Builder.Default
-    private Property<Boolean> store = Property.of(false);
+    private Property<Boolean> store = Property.ofValue(false);
 
     @Override
     public Find.Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/mongodb/Load.java
+++ b/src/main/java/io/kestra/plugin/mongodb/Load.java
@@ -65,7 +65,7 @@ public class Load extends AbstractLoad {
         title = "Whether to remove idKey from the final document."
     )
     @Builder.Default
-    private Property<Boolean> removeIdKey = Property.of(true);
+    private Property<Boolean> removeIdKey = Property.ofValue(true);
 
     @SuppressWarnings("unchecked")
     @Override

--- a/src/main/java/io/kestra/plugin/mongodb/MongoDbService.java
+++ b/src/main/java/io/kestra/plugin/mongodb/MongoDbService.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -64,7 +65,7 @@ public abstract class MongoDbService {
                         map(e.getValue())
                     ))
                     // https://bugs.openjdk.java.net/browse/JDK-8148463
-                    .collect(HashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), HashMap::putAll);
+                    .collect(LinkedHashMap::new, (m, v) -> m.put(v.getKey(), v.getValue()), LinkedHashMap::putAll);
             case ARRAY:
                 return doc.asArray()
                     .stream()

--- a/src/main/java/io/kestra/plugin/mongodb/Trigger.java
+++ b/src/main/java/io/kestra/plugin/mongodb/Trigger.java
@@ -84,7 +84,7 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
     private Property<Integer> skip;
 
     @Builder.Default
-    private Property<Boolean> store = Property.of(false);
+    private Property<Boolean> store = Property.ofValue(false);
 
     @Override
     public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception {

--- a/src/main/java/io/kestra/plugin/mongodb/Update.java
+++ b/src/main/java/io/kestra/plugin/mongodb/Update.java
@@ -98,7 +98,7 @@ public class Update extends AbstractTask implements RunnableTask<Update.Output> 
         title = "Operation to use."
     )
     @Builder.Default
-    private Property<Operation> operation = Property.of(Operation.UPDATE_ONE);
+    private Property<Operation> operation = Property.ofValue(Operation.UPDATE_ONE);
 
     @Override
     public Update.Output run(RunContext runContext) throws Exception {

--- a/src/test/java/io/kestra/plugin/mongodb/BulkTest.java
+++ b/src/test/java/io/kestra/plugin/mongodb/BulkTest.java
@@ -55,12 +55,12 @@ class BulkTest {
 
         Bulk put = Bulk.builder()
             .connection(MongoDbConnection.builder()
-                .uri(Property.of("mongodb://root:example@localhost:27017/?authSource=admin"))
+                .uri(Property.ofValue("mongodb://root:example@localhost:27017/?authSource=admin"))
                 .build())
-            .database(Property.of(database))
-            .collection(Property.of("bulk"))
-            .from(Property.of(uri.toString()))
-            .chunk(Property.of(10))
+            .database(Property.ofValue(database))
+            .collection(Property.ofValue("bulk"))
+            .from(Property.ofValue(uri.toString()))
+            .chunk(Property.ofValue(10))
             .build();
 
         Bulk.Output runOutput = put.run(runContext);

--- a/src/test/java/io/kestra/plugin/mongodb/CrudTest.java
+++ b/src/test/java/io/kestra/plugin/mongodb/CrudTest.java
@@ -28,9 +28,9 @@ class CrudTest {
         String database = "ut_" + IdUtils.create().toLowerCase(Locale.ROOT);
 
         InsertOne insert = InsertOne.builder()
-            .connection(MongoDbConnection.builder().uri(Property.of("mongodb://root:example@localhost:27017/?authSource=admin")).build())
-            .database(Property.of(database))
-            .collection(Property.of("insert"))
+            .connection(MongoDbConnection.builder().uri(Property.ofValue("mongodb://root:example@localhost:27017/?authSource=admin")).build())
+            .database(Property.ofValue(database))
+            .collection(Property.ofValue("insert"))
             .document(ImmutableMap.of(
                 "name", "{{ variable }}",
                 "tags", List.of("blue", "green", "red")
@@ -41,10 +41,10 @@ class CrudTest {
         assertThat(insertOutput.getInsertedId() != null, is(true));
 
         Update update = Update.builder()
-            .connection(MongoDbConnection.builder().uri(Property.of("mongodb://root:example@localhost:27017/?authSource=admin")).build())
-            .database(Property.of(database))
-            .collection(Property.of("insert"))
-            .operation(Property.of(Update.Operation.REPLACE_ONE))
+            .connection(MongoDbConnection.builder().uri(Property.ofValue("mongodb://root:example@localhost:27017/?authSource=admin")).build())
+            .database(Property.ofValue(database))
+            .collection(Property.ofValue("insert"))
+            .operation(Property.ofValue(Update.Operation.REPLACE_ONE))
             .document(ImmutableMap.of(
                 "name", "{{ variable }}",
                 "tags", List.of("green", "red")
@@ -59,9 +59,9 @@ class CrudTest {
 
 
         update = Update.builder()
-            .connection(MongoDbConnection.builder().uri(Property.of("mongodb://root:example@localhost:27017/?authSource=admin")).build())
-            .database(Property.of(database))
-            .collection(Property.of("insert"))
+            .connection(MongoDbConnection.builder().uri(Property.ofValue("mongodb://root:example@localhost:27017/?authSource=admin")).build())
+            .database(Property.ofValue(database))
+            .collection(Property.ofValue("insert"))
             .document("{\"$set\": { \"tags\": [\"blue\", \"green\", \"red\"]}}")
             .filter(ImmutableMap.of(
                 "_id", ImmutableMap.of("$oid", insertOutput.getInsertedId())
@@ -73,10 +73,10 @@ class CrudTest {
 
         Find find = Find.builder()
             .connection(MongoDbConnection.builder()
-                .uri(Property.of("mongodb://root:example@localhost:27017/?authSource=admin"))
+                .uri(Property.ofValue("mongodb://root:example@localhost:27017/?authSource=admin"))
                 .build())
-            .database(Property.of(database))
-            .collection(Property.of("insert"))
+            .database(Property.ofValue(database))
+            .collection(Property.ofValue("insert"))
             .filter(ImmutableMap.of(
                 "_id", ImmutableMap.of("$oid", insertOutput.getInsertedId())
             ))
@@ -88,10 +88,10 @@ class CrudTest {
 
         Delete delete = Delete.builder()
             .connection(MongoDbConnection.builder()
-                .uri(Property.of("mongodb://root:example@localhost:27017/?authSource=admin"))
+                .uri(Property.ofValue("mongodb://root:example@localhost:27017/?authSource=admin"))
                 .build())
-            .database(Property.of(database))
-            .collection(Property.of("insert"))
+            .database(Property.ofValue(database))
+            .collection(Property.ofValue("insert"))
             .filter(ImmutableMap.of(
                 "_id", ImmutableMap.of("$oid", insertOutput.getInsertedId())
             ))

--- a/src/test/java/io/kestra/plugin/mongodb/LoadTest.java
+++ b/src/test/java/io/kestra/plugin/mongodb/LoadTest.java
@@ -49,12 +49,12 @@ class LoadTest {
 
         Load put = Load.builder()
             .connection(MongoDbConnection.builder()
-                .uri(Property.of("mongodb://root:example@localhost:27017/?authSource=admin"))
+                .uri(Property.ofValue("mongodb://root:example@localhost:27017/?authSource=admin"))
                 .build())
-            .database(Property.of(database))
-            .collection(Property.of("load"))
-            .from(Property.of(uri.toString()))
-            .chunk(Property.of(10))
+            .database(Property.ofValue(database))
+            .collection(Property.ofValue("load"))
+            .from(Property.ofValue(uri.toString()))
+            .chunk(Property.ofValue(10))
             .build();
 
         Load.Output runOutput = put.run(runContext);


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
Preserves the key order when using `Find` task by using `LinkedHashMap`.

fixes #10 

