### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.3.2-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/main/java/io/kestra/plugin/mongodb/AbstractLoad.java
+++ b/src/main/java/io/kestra/plugin/mongodb/AbstractLoad.java
@@ -1,7 +1,7 @@
 package io.kestra.plugin.mongodb;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,7 +51,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
     @PluginProperty(group = "execution")
     private Property<Integer> chunk = Property.ofValue(1000);
 
-    abstract protected Flux<WriteModel<Bson>> source(RunContext runContext, BufferedReader inputStream) throws Exception;
+    abstract protected Flux<WriteModel<Bson>> source(RunContext runContext, InputStream inputStream) throws Exception;
 
     @Override
     public Output run(RunContext runContext) throws Exception {
@@ -60,7 +60,7 @@ public abstract class AbstractLoad extends AbstractTask implements RunnableTask<
 
         try (
             MongoClient client = this.connection.client(runContext);
-            BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE)
+            InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)
         ) {
             MongoCollection<Bson> collection = this.collection(runContext, client);
 

--- a/src/main/java/io/kestra/plugin/mongodb/Aggregate.java
+++ b/src/main/java/io/kestra/plugin/mongodb/Aggregate.java
@@ -20,6 +20,7 @@ import com.mongodb.client.MongoCollection;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -34,7 +35,6 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -238,7 +238,7 @@ public class Aggregate extends AbstractTask implements RunnableTask<Aggregate.Ou
     private Pair<URI, Long> store(RunContext runContext, AggregateIterable<BsonDocument> documents) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             var flux = Flux.fromIterable(documents).map(document -> MongoDbService.map(document.toBsonDocument()));
             Long count = FileSerde.writeAll(output, flux).block();
 

--- a/src/main/java/io/kestra/plugin/mongodb/Bulk.java
+++ b/src/main/java/io/kestra/plugin/mongodb/Bulk.java
@@ -2,6 +2,8 @@ package io.kestra.plugin.mongodb;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -82,9 +84,9 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
 )
 public class Bulk extends AbstractLoad {
     @Override
-    protected Flux<WriteModel<Bson>> source(RunContext runContext, BufferedReader inputStream) throws IOException {
+    protected Flux<WriteModel<Bson>> source(RunContext runContext, InputStream inputStream) throws IOException {
         return Flux
-            .create(this.ndJSonReader(inputStream), FluxSink.OverflowStrategy.BUFFER);
+            .create(this.ndJSonReader(new BufferedReader(new InputStreamReader(inputStream))), FluxSink.OverflowStrategy.BUFFER);
     }
 
     public Consumer<FluxSink<WriteModel<Bson>>> ndJSonReader(BufferedReader input) throws IOException {

--- a/src/main/java/io/kestra/plugin/mongodb/Find.java
+++ b/src/main/java/io/kestra/plugin/mongodb/Find.java
@@ -196,7 +196,7 @@ public class Find extends AbstractTask implements RunnableTask<Find.Output> {
     private Pair<URI, Long> store(RunContext runContext, FindIterable<BsonDocument> documents) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             var flux = Flux.fromIterable(documents).map(document -> MongoDbService.map(document.toBsonDocument()));
             Long count = FileSerde.writeAll(output, flux).block();
 

--- a/src/main/java/io/kestra/plugin/mongodb/Load.java
+++ b/src/main/java/io/kestra/plugin/mongodb/Load.java
@@ -1,6 +1,6 @@
 package io.kestra.plugin.mongodb;
 
-import java.io.BufferedReader;
+import java.io.InputStream;
 import java.util.Map;
 
 import org.bson.BsonDocument;
@@ -14,6 +14,7 @@ import com.mongodb.client.model.WriteModel;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
@@ -26,7 +27,6 @@ import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -93,7 +93,7 @@ public class Load extends AbstractLoad {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected Flux<WriteModel<Bson>> source(RunContext runContext, BufferedReader inputStream) throws Exception {
+    protected Flux<WriteModel<Bson>> source(RunContext runContext, InputStream inputStream) throws Exception {
         return FileSerde.readAll(inputStream)
             .map(throwFunction(o ->
             {

--- a/src/test/java/io/kestra/plugin/mongodb/AggregateTest.java
+++ b/src/test/java/io/kestra/plugin/mongodb/AggregateTest.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.mongodb;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
 import java.util.*;
 import java.util.Map;
 
@@ -19,7 +18,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.serializers.FileSerde;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -252,15 +251,8 @@ class AggregateTest extends MongoDbContainer {
         assertThat(output.getSize(), is(2L));
 
         // Verify stored file content
-        try (
-            var inputStream = runContext.storage().getFile(output.getUri());
-            var reader = new BufferedReader(new InputStreamReader(inputStream))
-        ) {
-            List<Object> storedRows = new ArrayList<>();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                storedRows.add(JacksonMapper.ofIon().readValue(line, Object.class));
-            }
+        try (var inputStream = new BufferedInputStream(runContext.storage().getFile(output.getUri()))) {
+            List<Object> storedRows = FileSerde.readAll(inputStream).collectList().block();
             assertThat(storedRows.size(), is(2));
         }
     }


### PR DESCRIPTION
Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155).

## Changes
- `gradle.properties`: bump `kestraVersion` to `1.3.19`
- `AbstractLoad.java`: `BufferedReader`/`InputStreamReader` → `BufferedInputStream`/`InputStream`
- `Load.java`: update `source()` signature from `BufferedReader` to `InputStream`
- `Bulk.java`: update `source()` signature; wrap InputStream in BufferedReader internally for line-based NDJSON parsing
- `Find.java`: `BufferedWriter`/`FileWriter` → `BufferedOutputStream`/`FileOutputStream`
- `Aggregate.java`: `BufferedWriter`/`FileWriter` → `BufferedOutputStream`/`FileOutputStream`
- `AggregateTest.java`: update stored file verification to use `FileSerde.readAll(InputStream)` instead of manual line-by-line ION text parsing